### PR TITLE
Improve USB detection with /proc/mounts fallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -55,6 +55,20 @@ def find_usb_mounts():
                     mounts.append(mount_point)
     except Exception as e:  # pragma: no cover - dépend du système
         logger.info(f"[USB] Erreur de détection: {e}")
+    if not mounts:
+        try:
+            with open('/proc/mounts') as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        mount_point = parts[1]
+                        if (
+                            mount_point.startswith('/media/')
+                            or mount_point.startswith('/run/media/')
+                        ) and mount_point not in mounts:
+                            mounts.append(mount_point)
+        except Exception as e:
+            logger.info(f"[USB] Fallback detection error: {e}")
     return mounts
 
 def check_printer_status():


### PR DESCRIPTION
## Summary
- fallback to /proc/mounts when lsblk fails to identify USB devices

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0542fe4a8832a88645a4a10a9bd6f