### PR TITLE
Add Photos USB button next to capture

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -46,9 +46,13 @@
             <div style="font-size: 8rem; font-weight: bold; color: black; text-shadow: none;">CHEESE!</div>
         </div>
         
-        <!-- Bouton capture en overlay -->
-        <div class="position-absolute bottom-0 start-50 translate-middle-x mb-4" style="z-index: 5;">
-            <button id="captureBtn" class="btn btn-danger btn-lg px-5 py-3" onclick="capturePhoto()" 
+        <!-- Boutons en overlay -->
+        <div class="position-absolute bottom-0 start-50 translate-middle-x mb-4 d-flex gap-3" style="z-index: 5;">
+            <a href="{{ url_for('usb_photos') }}" class="btn btn-secondary btn-lg px-4 py-3"
+               style="font-size: 1.2rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
+                <i class="fas fa-folder-open me-2"></i>Photos USB
+            </a>
+            <button id="captureBtn" class="btn btn-danger btn-lg px-5 py-3" onclick="capturePhoto()"
                     style="font-size: 1.5rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
                 <i class="fas fa-camera fa-2x"></i>
             </button>


### PR DESCRIPTION
## Summary
- Show a "Photos USB" button beside the capture button on the main page

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c05ff08524832a8c069e7b941a3fab