### PR TITLE
Keep capture message visible for 2 seconds

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -190,12 +190,12 @@ function capturePhoto() {
                 flashOverlay.classList.remove('d-none');
                 flashOverlay.classList.add('show');
 
-                // Masquer le flash après un court délai et prendre la photo
+                // Masquer le flash après un délai de 2 secondes et prendre la photo
                 setTimeout(() => {
                     flashOverlay.classList.remove('show');
                     flashOverlay.classList.add('d-none');
                     takePicture();
-                }, 300);
+                }, 2000);
             }, 200);
         }
     }, 1000);


### PR DESCRIPTION
## Summary
- Extend flash overlay duration before photo capture from 0.3s to 2s, keeping the message visible longer

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c061707d20832aafb61ec7a0697faf