### PR TITLE
style: align USB photo button with primary color and icon

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,9 +48,10 @@
         
         <!-- Boutons en overlay -->
         <div class="position-absolute bottom-0 start-50 translate-middle-x mb-4 d-flex gap-3" style="z-index: 5;">
-            <a href="{{ url_for('usb_photos') }}" class="btn btn-secondary btn-lg px-4 py-3"
+            <a href="{{ url_for('usb_photos') }}" class="btn btn-primary btn-lg px-4 py-3 d-flex flex-column align-items-center"
                style="font-size: 1.2rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">
-                <i class="fas fa-folder-open me-2"></i>Photos USB
+                <i class="fas fa-usb mb-1" style="font-size: 1.5rem;"></i>
+                <span>Photo USB</span>
             </a>
             <button id="captureBtn" class="btn btn-danger btn-lg px-5 py-3" onclick="capturePhoto()"
                     style="font-size: 1.5rem; border-radius: 50px; box-shadow: 0 4px 15px rgba(0,0,0,0.3);">


### PR DESCRIPTION
## Summary
- match "Photo USB" button color to "Reprendre" button
- display USB icon above "Photo USB" label

## Testing
- `python -m pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c063a9a6f4832ab9332ef036e6aaec