### PR TITLE
Scale countdown text with screen size

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -87,7 +87,7 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            font-size: 8em;
+            font-size: min(30vw, 30vh);
             color: white;
             font-weight: bold;
             text-shadow: 2px 2px 4px rgba(0,0,0,0.8);
@@ -137,7 +137,7 @@
             }
 
             .countdown {
-                font-size: 6em;
+                font-size: min(35vw, 35vh);
             }
         }
 
@@ -154,7 +154,7 @@
             }
 
             .countdown {
-                font-size: 5em;
+                font-size: min(35vw, 35vh);
             }
         }
 
@@ -171,7 +171,7 @@
             }
 
             .countdown {
-                font-size: 4em;
+                font-size: min(40vw, 40vh);
             }
         }
     </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -107,7 +107,7 @@ const funMessages = [
 
 function fitTextToContainer(el) {
     const container = document.getElementById('videoContainer');
-    let size = Math.min(container.clientWidth, container.clientHeight) * 0.6;
+    let size = Math.min(container.clientWidth, container.clientHeight) * 0.8;
     el.style.fontSize = size + 'px';
     el.style.whiteSpace = 'normal';
     el.style.width = '90%';


### PR DESCRIPTION
## Summary
- scale countdown text using viewport-based font sizes
- enlarge dynamic countdown sizing logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c08a57b8bc832aaade849c6f18aaf7